### PR TITLE
update email template styling

### DIFF
--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -338,8 +338,8 @@ class EmailService():
             .socialmedia {{
                 margin: 24px
             }}
-            footer {{
-                background-color:black;
+            .footer {{
+                background-color: #101010;
                 color:white;
                 text-align:center;
                 padding:1.2em;
@@ -348,7 +348,7 @@ class EmailService():
                 p {{
                     font-size:1.2em !important;
                 }}
-                footer > p, .settingscontainer {{
+                .footer > p, .settingscontainer {{
                     font-size:1.0em !important;
                 }}
                 .img1 {{
@@ -384,8 +384,7 @@ class EmailService():
         </a>
         
         </div>
-        </body>
-        <footer>
+        <div class="footer">
             <div class="socialmedia">
                 <a href="https://www.facebook.com/8by8vote" target="_blank">
                     <img width="20" height="20" src="cid:facebook">
@@ -403,7 +402,8 @@ class EmailService():
             <p>
                 8BY8 is a nonprofit organization dedicated to stopping hate against Asian American Pacific Islander communities through voter registration and turnout.
             </p>
-        </footer>
+        </div>
+        </body>
         </html>'''.format(buttonSize=buttonSize, h1=content['h1'], p1=paragraph, endDate=endDateStr, firstName=firstName.upper(), img1Class=content['img1Class'], 
                           btn1Link=btn1Link, btn1=content['btn1'], h2=content['h2'], img2Class=content['img2Class'], daysLeft=daysLeft,
                           p2=content['p2'], badgesLeft=badgesLeft, p3=content['p3'], btn2Link=btn2Link, btn2=content['btn2'])
@@ -450,9 +450,9 @@ class EmailService():
         msgImage.add_header('Content-ID', '<instagram>')
         message.attach(msgImage)
         
-        #raw_message = \
-        #    base64.urlsafe_b64encode(message.as_string().encode('utf-8'))
-        #return {'raw': raw_message.decode('utf-8')}
+        raw_message = \
+           base64.urlsafe_b64encode(message.as_string().encode('utf-8'))
+        return {'raw': raw_message.decode('utf-8')}
         return message.as_string()
 
             

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -230,8 +230,11 @@ class EmailService():
         <head>
         <style>
             @import url('https://fonts.googleapis.com/css2?family=Lato&family=Oswald&display=swap');
-            body {{
-                margin:0;
+            .app {{
+                margin: 0 auto;
+                max-width: 500px;
+                min-width: 375px;
+                background-color: white;
             }}
             h1 {{
                 font-size:22pt;
@@ -253,8 +256,7 @@ class EmailService():
                 font-size:1.1em;
             }}
             .img8by8 {{
-                max-width:420px;
-                max-height:296px;
+                width:100%;
             }}
             .img1 {{
                 max-width:16em;
@@ -352,6 +354,9 @@ class EmailService():
                 text-align:center;
                 padding:1.2em;
             }}
+            img {{
+                margin: 0 auto;
+            }}
             @media only screen and (max-width: 500px) {{
                 p {{
                     font-size:1.2em !important;
@@ -369,6 +374,7 @@ class EmailService():
         </style>
         </head>
         <body>
+        <div class="app">
         <div class="content">
         <img class="img8by8" src="cid:image0">
         <h1>{h1}</h1>
@@ -410,6 +416,7 @@ class EmailService():
             <p>
                 8BY8 is a nonprofit organization dedicated to stopping hate against Asian American Pacific Islander communities through voter registration and turnout.
             </p>
+        </div>
         </div>
         </body>
         </html>'''.format(buttonSize=buttonSize, h1=content['h1'], p1=paragraph, endDate=endDateStr, firstName=firstName.upper(), img1Class=content['img1Class'], 

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -281,7 +281,7 @@ class EmailService():
             }}
             button {{
                 font-family: 'Oswald', sans-serif;
-                border: solid black 0.25rem;
+                border: solid #101010 0.25rem;
                 font-size:16pt;
                 padding:0.4em;
                 padding-left:1.4em;
@@ -293,22 +293,30 @@ class EmailService():
                 border-bottom-right-radius:2.3em 100%;
                 cursor: pointer;
             }}
-            .btn1, btn2 {{
+            .btn1, .btn2 {{
                 font-size:{buttonSize}pt;
             }}
             .btn1 {{
                 background: linear-gradient(90deg, #02DDC3, #FFED10);
-                color: black;
+                color: #101010;
                 margin-top: 0.8em;
             }}
             .btn2 {{
-                background-color:black;
+                background-color: #101010;
                 color:white;
                 margin-top: 0.7em;
                 margin-bottom: 1.5em;
             }}
+
+            .btn2 > span {{
+                color: white;
+                background-image: linear-gradient(90deg, #02DDC3, #FFED10);
+                -webkit-background-clip: text;
+                -webkit-text-fill-color: transparent;  
+            }}
+
             a {{
-                color:black !important;
+                color: #101010 !important;
                 font-weight: bold;
             }}
             .content {{
@@ -380,7 +388,7 @@ class EmailService():
         <p><b>{daysLeft}</b>{p2}</p>
         <p><b>{badgesLeft}</b>{p3}</p>
         <a class="abtn2" href="{btn2Link}">
-        <button class="btn2">{btn2}</button>
+        <button class="btn2"><span>{btn2}</span></button>
         </a>
         
         </div>

--- a/app/services/email_service.py
+++ b/app/services/email_service.py
@@ -394,7 +394,7 @@ class EmailService():
         <p><b>{daysLeft}</b>{p2}</p>
         <p><b>{badgesLeft}</b>{p3}</p>
         <a class="abtn2" href="{btn2Link}">
-        <button class="btn2"><span>{btn2}</span></button>
+        <button class="btn2">{btn2}</button>
         </a>
         
         </div>


### PR DESCRIPTION
[Issue](https://github.com/8by8-org/web-app/issues/153#issue-1292443412): fix the styling of the footer and set the max-width to the body so it's easier to read.

Test: Tested in outlook.com, gmail.com, and iOS/macOS Mail.app

1. iOS 
<img width="283" alt="iOS" src="https://user-images.githubusercontent.com/31695656/177657437-f0e02efb-a44d-4f0b-822c-3edc903fd324.jpeg">
2. outlook 
<img width="283" alt="outlook" src="https://user-images.githubusercontent.com/31695656/177657441-ddbb4b18-a458-40fa-860b-ed66b6f5caec.png">
3. gmail 
<img width="268" alt="gmail" src="https://user-images.githubusercontent.com/31695656/177657443-d15cc919-b456-4cc6-955c-49c582730dbf.png">
4. macOS 
<img width="267" alt="macOS" src="https://user-images.githubusercontent.com/31695656/177657444-3aa19a50-c67b-4fd1-874b-5801641bca92.png">

Existing problems: 
1. Images do not align at the center in the default Mail.app of macOS at some specific window width.
![macOS-issue](https://user-images.githubusercontent.com/31695656/177657628-a736de62-e9f4-42fa-a811-62fb53b484ac.gif)
2. The gradient-colored text in button 2 doesn't work in Outlook and Gmail.
3. The font looks different in almost every email client